### PR TITLE
Incorporating muon neutrino events into signal and adding proton kinematics characterization in signal events.

### DIFF
--- a/auxiliary.py
+++ b/auxiliary.py
@@ -4,7 +4,7 @@ import json
 
 neutral_pdg=[111] #, 22] #, 2112] # add K0, rho0, eta0?
 meson_pdg={111,211,-211,130,310,311,321,-321,221,331,421,-421,411,-411, 431,-431}
-nu_signal_pdg=-14
+nu_mu_pdg=14
 
 hadron_pdg_dict ={2112:'n',
                   2212:'p',
@@ -94,7 +94,7 @@ def save_dict_to_json(d, name, if_tuple):
 def signal_nu_pdg(ghdr, vert_id):
     ghdr_vert_mask = ghdr['vertexID']==vert_id
     ghdr_nu_interaction = ghdr[ghdr_vert_mask]['nu_pdg']
-    if ghdr_nu_interaction[0]==nu_signal_pdg: return True
+    if abs(ghdr_nu_interaction[0])==nu_mu_pdg: return True
     else: return False
 
 
@@ -102,18 +102,10 @@ def signal_cc(ghdr, vert_id):
     ghdr_vert_mask = ghdr['vertexID']==vert_id
     return ghdr[ghdr_vert_mask]['isCC'][0]
 
-
-
 def signal_meson_status(gstack, vert_id):
     gstack_vert_mask = gstack['vertexID']==vert_id
     gstack_pdg_set = set(gstack[gstack_vert_mask]['part_pdg'])
     if len(meson_pdg.intersection(gstack_pdg_set))==0: return True
-    else: return False
-
-def wrong_sign_nu_pdg(ghdr, vert_id):
-    ghdr_vert_mask = ghdr['vertexID']==vert_id
-    ghdr_nu_interaction = ghdr[ghdr_vert_mask]['nu_pdg']
-    if ghdr_nu_interaction[0]== -1*nu_signal_pdg: return True
     else: return False
 
 def nu_int_type(ghdr, vert_id):
@@ -184,7 +176,7 @@ def same_pdg_connected_trajectories(track_pdg, track_id, vertex_assoc_traj,\
     return trackid_set
     
 
-def is_primary_particle(trackid_set, vertex_assoc_traj,traj, ghdr, wrong_sign):
+def is_primary_particle(trackid_set, vertex_assoc_traj,traj, ghdr):
     is_prim = False
 
     for tid in trackid_set:
@@ -194,10 +186,7 @@ def is_primary_particle(trackid_set, vertex_assoc_traj,traj, ghdr, wrong_sign):
                                      vertex_assoc_traj[particle_mask]['vertexID'],
                                      traj, ghdr)
         #print("Parent PDG:", parent_pdg)
-        if wrong_sign==False and parent_pdg==-14:
-            is_prim = True
-            break
-        if wrong_sign==True and parent_pdg==14:
+        if abs(parent_pdg)==14:
             is_prim = True
             break
         else: continue

--- a/plot_signal_hadrons.py
+++ b/plot_signal_hadrons.py
@@ -162,7 +162,121 @@ def plot_hadrons(d, scale_factor, sig_bkg = 0):
         #ax8.hist(bins8cont[:-1], bins=bins8cont, weights = counts8cont*scale_factor, label='Contained',histtype='step', linestyle='--')
         ax8.set_xlabel(r"Length [cm]")
         ax8.set_title("Length of Longest Proton Track in "+sample_title+" Events with Neutrons and Protons")
-        ax8.set_ylabel("Count / cm") 
+        ax8.set_ylabel("Events / cm") 
         #ax8.legend()
         plt.savefig(sample_type+"_events_max_proton_length_in_pn_events_truth.png")   
     plt.close(fig8)
+
+    # PLOT: hadron multiplicity above threshold
+    fig9, ax9 = plt.subplots(figsize=(6,4))
+    data9 = np.array([d[key]['hadron_mult_over_thresh'] for key in d.keys()])
+    counts9, bins9 =np.histogram(data9, bins=np.linspace(0,12,13))
+    ax9.hist(bins9[:-1], bins=bins9, weights = counts9*scale_factor, histtype='step')
+    ax9.set_xlabel(r"Primary Hadron Multiplicity Above Threshold")
+    ax9.set_ylabel("Events / Hadron") 
+    plt.savefig(sample_type+"_events_hadron_multiplicity_above_threshold.png")
+    plt.close(fig9)  
+
+    # PLOT: proton multiplicity above threshold
+    fig10, ax10 = plt.subplots(figsize=(6,4))
+    data10 = np.array([d[key]['proton_mult_over_thresh'] for key in d.keys()])
+    counts10, bins10 =np.histogram(data10, bins=np.linspace(0,12,13))
+    ax10.hist(bins10[:-1], bins=bins10, weights = counts10*scale_factor, histtype='step')
+    ax10.set_xlabel(r"Primary Proton Multiplicity Above Threshold")
+    ax10.set_ylabel("Events / Proton") 
+    plt.savefig(sample_type+"_events_proton_multiplicity_above_threshold.png")
+    plt.close(fig10)   
+
+    # PLOT: Lead proton momentum for events with protons
+    fig11, ax11 = plt.subplots(figsize=(8,4))
+    p_lead_mom = []
+    events_w_protons = 0
+    for key in d.keys():
+        if d[key]['proton_mult_over_thresh']>0:
+            p_lead_mom.append(d[key]['lead_proton_momentum'])
+            events_w_protons+=1
+    if events_w_protons >0:  
+        data11tot = np.array(p_lead_mom)
+        counts11tot, bins11tot = np.histogram(data11tot, bins=np.linspace(0,2000,41))
+        ax11.hist(bins11tot[:-1], bins=bins11tot, weights = counts11tot*scale_factor, histtype='step')
+        ax11.set_xlabel(r"Momentum [MeV/c]")
+        ax11.set_title("Leading Proton Momenta in "+sample_title+" Events with Protons")
+        ax11.set_ylabel("Events / 50 MeV/c") 
+        plt.savefig(sample_type+"_lead_proton_momentum_events_with_protons_above_threshold.png")   
+    plt.close(fig11)
+
+    # PLOT: Sub-leading proton momentum for events with 2+ protons
+    fig12, ax12 = plt.subplots(figsize=(8,4))
+    p_sublead_mom = []
+    events_w_greq_2_protons = 0
+    for key in d.keys():
+        if d[key]['proton_mult_over_thresh']>1:
+            p_sublead_mom.append(d[key]['sub_lead_proton_momentum'])
+            events_w_greq_2_protons+=1
+    if events_w_greq_2_protons >0:  
+        data12tot = np.array(p_sublead_mom)
+        counts12tot, bins12tot = np.histogram(data12tot, bins=np.linspace(0,2000,41))
+        ax12.hist(bins12tot[:-1], bins=bins12tot, weights = counts12tot*scale_factor, histtype='step')
+        ax12.set_xlabel(r"Momentum [MeV/c]")
+        ax12.set_title("Subleading Proton Momenta in "+sample_title\
+                       +" Events with 2+ Protons Above Threshold")
+        ax12.set_ylabel("Events / 50 MeV/c") 
+        plt.savefig(sample_type+"_sublead_proton_momentum_events_with_greq_2_protons_above_threshold.png")   
+    plt.close(fig12)
+
+    # PLOT: Lead proton angle wrt beam for events with protons
+    fig13, ax13 = plt.subplots(figsize=(8,4))
+    p_lead_ang_wrt_beam = []
+    events_w_protons = 0
+    for key in d.keys():
+        if d[key]['proton_mult_over_thresh']>0:
+            p_lead_ang_wrt_beam.append(d[key]['lead_proton_ang_wrt_beam'])
+            events_w_protons+=1
+    if events_w_protons >0:  
+        data13tot = np.array(p_lead_ang_wrt_beam)
+        counts13tot, bins13tot = np.histogram(data13tot, bins=np.linspace(0,3.2,33))
+        ax13.hist(bins13tot[:-1], bins=bins13tot, weights = counts13tot*scale_factor, histtype='step')
+        ax13.set_xlabel(r"Angle [Rad]")
+        ax13.set_title("Leading Proton Angle with respect to Beam Direction in "+sample_title\
+                       +" Events with Protons Above Threshold")
+        ax13.set_ylabel("Events / 0.1 Rad") 
+        plt.savefig(sample_type+"_lead_proton_angle_wrt_beam_direction_events_with_protons_above_threshold.png")   
+    plt.close(fig13)
+
+    # PLOT: Subleading proton angle wrt beam for events with protons
+    fig14, ax14 = plt.subplots(figsize=(8,4))
+    p_sublead_ang_wrt_beam = []
+    events_w_greq_2_protons = 0
+    for key in d.keys():
+        if d[key]['proton_mult_over_thresh']>1:
+            p_sublead_ang_wrt_beam.append(d[key]['sub_lead_proton_ang_wrt_beam'])
+            events_w_greq_2_protons+=1
+    if events_w_greq_2_protons >0:  
+        data14tot = np.array(p_sublead_ang_wrt_beam)
+        counts14tot, bins14tot = np.histogram(data14tot, bins=np.linspace(0,3.2,33))
+        ax14.hist(bins14tot[:-1], bins=bins14tot, weights = counts14tot*scale_factor, histtype='step')
+        ax14.set_xlabel(r"Angle [Rad]")
+        ax14.set_title("Subleading Proton Angle with respect to Beam Direction in "+sample_title\
+                       +" Events with 2+ Protons Above Threshold")
+        ax14.set_ylabel("Events / 0.1 Rad") 
+        plt.savefig(sample_type+"_sublead_proton_angle_wrt_beam_direction_events_with_greq_2_protons_above_threshold.png")   
+    plt.close(fig14)
+
+    # PLOT: Subleading proton angle wrt beam for events with protons
+    fig15, ax15 = plt.subplots(figsize=(8,4))
+    p_sublead_ang_wrt_lead_proton = []
+    events_w_greq_2_protons = 0
+    for key in d.keys():
+        if d[key]['proton_mult_over_thresh']>1:
+            p_sublead_ang_wrt_lead_proton.append(d[key]['sub_lead_proton_angle_with_lead_proton'])
+            events_w_greq_2_protons+=1
+    if events_w_greq_2_protons >0:  
+        data15tot = np.array(p_sublead_ang_wrt_lead_proton)
+        counts15tot, bins15tot = np.histogram(data15tot, bins=np.linspace(0,3.2,33))
+        ax15.hist(bins15tot[:-1], bins=bins15tot, weights = counts15tot*scale_factor, histtype='step')
+        ax15.set_xlabel(r"Angle [Rad]")
+        ax15.set_title("Subleading Proton Angle with respect to Leading Proton Direction\n in "+sample_title \
+                       +" Events with 2+ Protons Above Threshold")
+        ax15.set_ylabel("Events / 0.1 Rad") 
+        plt.savefig(sample_type+"_sublead_proton_angle_wrt_lead_proton_events_with_greq_2_protons_above_threshold.png")   
+    plt.close(fig15)

--- a/plot_signal_hadrons.py
+++ b/plot_signal_hadrons.py
@@ -25,9 +25,6 @@ def plot_hadrons(d, scale_factor, sig_bkg = 0):
     elif sig_bkg == 2:
         sample_type = 'beam_bkg'
         sample_title = 'Beam Background'
-    elif sig_bkg == 3:
-        sample_type = 'wrong_sign_bkg'
-        sample_title = 'Wrong Sign Background'
     else: 
         return "Error: plot_hadrons function given undefined signal/background definition"
     

--- a/plot_signal_muons.py
+++ b/plot_signal_muons.py
@@ -25,9 +25,6 @@ def plot_muons(d, scale_factor, sig_bkg = 0):
     elif sig_bkg == 2:
         sample_type = 'beam_bkg'
         sample_title = 'Beam Background'
-    elif sig_bkg == 3:
-        sample_type = 'wrong_sign_bkg'
-        sample_title = 'Wrong Sign Background'
     else: 
         return "Error: plot_muons function given undefined signal/background definition"
     

--- a/plot_signal_muons.py
+++ b/plot_signal_muons.py
@@ -140,6 +140,8 @@ def plot_muons(d, scale_factor, sig_bkg = 0):
             data8u.append(d[key]['ang'])
             data9u.append(d[key]['mom'] / 1000.)
 
+    print("Minimum momentum of muons punching through MINERvA [GeV/c]:", np.min(data9b))
+
     fig6, ax6 = plt.subplots(figsize=(9,6))
     bins6 = np.linspace(0,15,31)
     counts6f, bins6f =np.histogram(np.array(data6f), bins=bins6)

--- a/signal_characterization.py
+++ b/signal_characterization.py
@@ -10,8 +10,8 @@ characterizing certain backgrounds as well.
 
 INCLUDED METHODS:
  - get_truth_dict(spill_id, vert_id, ghdr, gstack, traj, seg, signal_dict)
- - muon_characterization(spill_id, vert_id, ghdr, gstack, traj, seg, muon_dict, wrong_sign)
- - hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, seg, hadron_dict, wrong_sign)
+ - muon_characterization(spill_id, vert_id, ghdr, gstack, traj, seg, muon_dict)
+ - hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, seg, hadron_dict)
  '''
 
 
@@ -19,8 +19,8 @@ INCLUDED METHODS:
              and 
     Inputs : Spill ID (INT), Vertex ID (INT), genie_hdr dataset (HDF5 DATASET), 
              genie_stack dataset (HDF5 DATASET), edep-sim trajectories dataset (HDF5 DATASET), 
-             vertex dataset (HDF5 DATASET), edep-sim segements dataset (HDF5 DATASET), empty Python dictionary (DICT), 
-             signifier of looking for right sign nu_mu_bar vertices or wrong sign nu_mu vertices (BOOL)
+             vertex dataset (HDF5 DATASET), edep-sim segements dataset (HDF5 DATASET), 
+             empty Python dictionary (DICT)
     Outputs: Nothing returned, but signal_dict (DICT) is full after
              method runs'''
 def get_truth_dict(spill_id, vert_id, ghdr, gstack, traj, vert, seg, signal_dict):
@@ -52,11 +52,11 @@ def get_truth_dict(spill_id, vert_id, ghdr, gstack, traj, vert, seg, signal_dict
              related to FS muon
     Inputs : Spill ID (INT), Vertex ID (INT), genie_hdr dataset (HDF5 DATASET), 
              genie_stack dataset (HDF5 DATASET), edep-sim trajectories dataset (HDF5 DATASET), 
-             vertex dataset (HDF5 DATASET), edep-sim segements dataset (HDF5 DATASET), empty Python dictionary (DICT), 
-             signifier of looking for right sign nu_mu_bar vertices or wrong sign nu_mu vertices (BOOL)
+             vertex dataset (HDF5 DATASET), edep-sim segements dataset (HDF5 DATASET), 
+             empty Python dictionary (DICT)
     Outputs: Nothing returned, but muon_dict (DICT) is full after
              method runs'''
-def muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, muon_dict, wrong_sign):
+def muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, muon_dict):
 
     traj_vert_mask = traj['vertexID']==vert_id 
     final_states = traj[traj_vert_mask] # Get trajectories associated with vertex
@@ -80,8 +80,7 @@ def muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, muon
     for fs in final_states:
 
         # Choose nu_mu_bar or nu_mu vertices
-        if wrong_sign==False and (fs['pdgId'] != -13): continue
-        elif wrong_sign==True and (fs['pdgId'] != 13): continue
+        if (abs(fs['pdgId']) != 13): continue
         
         track_id = fs['trackID']
         if track_id in exclude_track_ids: continue
@@ -92,7 +91,7 @@ def muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, muon
         track_id_set = auxiliary.same_pdg_connected_trajectories(pdg, track_id, final_states, traj, ghdr)
         exclude_track_ids.update(track_id_set) # Exclude track IDs associated with same particle from future counting
 
-        is_primary = auxiliary.is_primary_particle(track_id_set, final_states, traj, ghdr, wrong_sign) 
+        is_primary = auxiliary.is_primary_particle(track_id_set, final_states, traj, ghdr) 
 
         if is_primary == False: continue # Only look at final state particles
         for tid in track_id_set:
@@ -130,11 +129,11 @@ def muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, muon
              related to hadrons 
     Inputs : Spill ID (INT), Vertex ID (INT), genie_hdr dataset (HDF5 DATASET), 
              genie_stack dataset (HDF5 DATASET), edep-sim trajectories dataset (HDF5 DATASET), 
-             vertex dataset (HDF5 DATASET), edep-sim segements dataset (HDF5 DATASET), empty Python dictionary (DICT), 
-             signifier of looking for right sign nu_mu_bar vertices or wrong sign nu_mu vertices (BOOL)
+             vertex dataset (HDF5 DATASET), edep-sim segements dataset (HDF5 DATASET), 
+             empty Python dictionary (DICT)
     Outputs: Nothing returned, but hadron_dict (DICT) is full after
              method runs'''
-def hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, hadron_dict, wrong_sign):
+def hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, hadron_dict):
         
     traj_vert_mask = traj['vertexID']==vert_id
     final_states = traj[traj_vert_mask] # Trajectories associated with vertex
@@ -198,7 +197,7 @@ def hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, ha
                 proton_total_length+=auxiliary.total_edep_charged_length(tid, traj, seg)
 
         if fs['pdgId'] == 2212 and proton_contained_length > max_proton_contained_length and \
-            auxiliary.is_primary_particle(track_id_set, final_states, traj, ghdr, wrong_sign):
+            auxiliary.is_primary_particle(track_id_set, final_states, traj, ghdr):
             max_proton_contained_length = proton_contained_length # Update max contained proton length in vertex
             max_proton_total_length = proton_total_length # Update max total proton length in vertex
 

--- a/signal_characterization.py
+++ b/signal_characterization.py
@@ -4,6 +4,9 @@ import twoBytwo_defs
 import numpy as np
 import auxiliary
 
+''' TO DO: Add other hadron mult over threshold? '''
+
+
 '''
 NOTE: While script is labelled as 'signal' characterization, methods can be used for
 characterizing certain backgrounds as well.
@@ -129,12 +132,13 @@ def muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, muon
              related to hadrons 
     Inputs : Spill ID (INT), Vertex ID (INT), genie_hdr dataset (HDF5 DATASET), 
              genie_stack dataset (HDF5 DATASET), edep-sim trajectories dataset (HDF5 DATASET), 
-             vertex dataset (HDF5 DATASET), edep-sim segements dataset (HDF5 DATASET), 
+             vertex dataset (HDF5 DATASET), edep-sim segements dataset (HDF5 DATASET), threshold length in cm (FLOAT)
              empty Python dictionary (DICT)
     Outputs: Nothing returned, but hadron_dict (DICT) is full after
              method runs'''
-def hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, hadron_dict):
+def hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, threshold, hadron_dict):
         
+    #print("\nHADRONS:")
     traj_vert_mask = traj['vertexID']==vert_id
     final_states = traj[traj_vert_mask] # Trajectories associated with vertex
 
@@ -169,8 +173,12 @@ def hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, ha
         else:
             other_had_mult+=1
 
-    # Set contained and total track energies and lengths to 0
-    total_edep=0.; contained_edep=0.; total_length=0.; contained_length=0.; max_proton_contained_length=0.; max_proton_total_length=0. 
+    # Set contained and total track energies and lengths to 0; Set hadron + proton multiplicities over threshold to 0.
+    total_edep=0.; contained_edep=0.; total_length=0.; contained_length=0.
+    max_proton_contained_length=0.; max_proton_total_length=0. 
+    lead_proton_ang_wrt_beam=0.; lead_proton_momentum=0.; sub_lead_proton_ang_wrt_beam=0.; sub_lead_proton_momentum=0.
+    lead_proton_traj_at_vertex = 0.; sub_lead_proton_traj_at_vertex = 0.
+    hadron_mult_over_thresh = 0.; p_mult_over_thresh = 0.
     
     exclude_track_ids = set() # Create set of track IDs to exclude to eliminate redundancies
                               # (i.e. if they've been identified as being from the same particle as an earlier track)
@@ -181,25 +189,57 @@ def hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, ha
         if fs['pdgId'] == 22: continue # No photons
         
         track_id = fs['trackID']
-        if track_id in exclude_track_ids: continue 
+        if track_id in exclude_track_ids: 
+            #print("Excluding a track because it has already been studied.")
+            continue 
 
         track_id_set = auxiliary.same_pdg_connected_trajectories(fs['pdgId'], track_id, final_states, traj, ghdr)
         exclude_track_ids.update(track_id_set) # Exclude track IDs associated with same particle from future counting
+        #if fs['pdgId'] == 2112: print("\nTrack ID Set:", track_id_set)
 
         proton_contained_length = 0.; proton_total_length=0. # Reset proton track lengths
         for tid in track_id_set:
 
             total_edep += auxiliary.total_edep_charged_e(tid,traj,seg) # *** total visible energy ***
             contained_edep+= auxiliary.fv_edep_charged_e(tid, traj, seg)
+
+            contained_length+=auxiliary.fv_edep_charged_length(tid, traj, seg) # *** total contained length for protons ***
+            total_length+=auxiliary.total_edep_charged_length(tid, traj, seg)
             
             if fs['pdgId'] == 2212:
                 proton_contained_length+=auxiliary.fv_edep_charged_length(tid, traj, seg) # *** total contained length for protons ***
                 proton_total_length+=auxiliary.total_edep_charged_length(tid, traj, seg)
 
-        if fs['pdgId'] == 2212 and proton_contained_length > max_proton_contained_length and \
-            auxiliary.is_primary_particle(track_id_set, final_states, traj, ghdr):
-            max_proton_contained_length = proton_contained_length # Update max contained proton length in vertex
-            max_proton_total_length = proton_total_length # Update max total proton length in vertex
+        if auxiliary.is_primary_particle(track_id_set, final_states, traj, ghdr) and contained_length > threshold \
+            and fs['pdgId'] not in auxiliary.neutral_hadron_pdg_dict.keys():
+            hadron_mult_over_thresh +=1
+            if fs['pdgId'] == 2212: 
+                p_mult_over_thresh += 1
+                p_traj_id_at_vertex = auxiliary.find_trajectory_at_vertex(track_id_set, final_states, traj, ghdr)
+                trackid_at_vertex_mask = final_states['trackID']==p_traj_id_at_vertex
+                p_track_at_vertex = final_states[trackid_at_vertex_mask] 
+                p_mom = np.sqrt(np.sum(p_track_at_vertex['pxyz_start']**2))
+                if p_mom > lead_proton_momentum:
+                    sub_lead_proton_traj_at_vertex = lead_proton_traj_at_vertex
+                    sub_lead_proton_momentum = lead_proton_momentum
+                    sub_lead_proton_ang_wrt_beam = lead_proton_ang_wrt_beam
+
+                    lead_proton_traj_at_vertex = p_traj_id_at_vertex
+                    lead_proton_momentum = p_mom
+                    lead_proton_ang_wrt_beam = auxiliary.angle_wrt_beam_direction(track_id_set, final_states, traj, ghdr)
+                elif p_mom <= lead_proton_momentum and p_mom > sub_lead_proton_momentum:
+                    sub_lead_proton_traj_at_vertex = p_traj_id_at_vertex
+                    sub_lead_proton_momentum = p_mom
+                    sub_lead_proton_ang_wrt_beam = auxiliary.angle_wrt_beam_direction(track_id_set, final_states, traj, ghdr)
+                
+                if proton_contained_length > max_proton_contained_length:
+                    max_proton_contained_length = proton_contained_length # Update max contained proton length in vertex
+                    max_proton_total_length = proton_total_length # Update max total proton length in vertex
+
+    angle_between_lead_and_sublead_protons = 0. # Initialize angle between leading and subleading protons
+    if p_mult_over_thresh >= 2:
+        angle_between_lead_and_sublead_protons = auxiliary.angle_between_two_trajectories(lead_proton_traj_at_vertex, \
+                                                                                          sub_lead_proton_traj_at_vertex, final_states)
 
     # Save collected info in input hadron_dict
     hadron_dict[(spill_id,vert_id)]=dict(
@@ -207,11 +247,18 @@ def hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, ha
         neutron_mult = int(n_mult),
         proton_mult = int(p_mult),
         other_had_mult = int(other_had_mult),
+        hadron_mult_over_thresh = int(hadron_mult_over_thresh),
+        proton_mult_over_thresh = int(p_mult_over_thresh),
         hadron_pdg = [int(i) for i in gstack_vert_fs_hadrons],
         hadron_pdg_set = [int(i) for i in list(gstack_vert_fs_pdg_set)],
         total_edep=float(total_edep),
         contained_edep=float(contained_edep),
         max_p_total_length=float(max_proton_total_length),
-        max_p_contained_length=float(max_proton_contained_length))
+        max_p_contained_length=float(max_proton_contained_length),
+        lead_proton_momentum = float(lead_proton_momentum), 
+        sub_lead_proton_momentum = float(sub_lead_proton_momentum), 
+        lead_proton_ang_wrt_beam = float(lead_proton_ang_wrt_beam), 
+        sub_lead_proton_ang_wrt_beam = float(sub_lead_proton_ang_wrt_beam),
+        sub_lead_proton_angle_with_lead_proton = float(angle_between_lead_and_sublead_protons))
     return
                                                  

--- a/signal_kinematics.py
+++ b/signal_kinematics.py
@@ -24,12 +24,8 @@ def main(sim_dir, input_type, n_files_processed):
     muon_dict = dict() # Initialize muon dictionary
     hadron_dict = dict() # Initialize hadron dictionary
 
-    ws_muon_dict = dict() # Initialize wrong sign muon dictionary
-    ws_hadron_dict = dict() # Initialize wrong sign hadron dictionary
-    
     # Dictionaries for combining with other background explorations
     signal_dict = dict() # Initialize dictionary for signal muons for full comparison
-    wrong_sign_bkg_dict = dict() # Initialize dictionary for wrong sign bkg muons for full comparison
     
     file_ext = '' ## Changes based on input type
 
@@ -65,37 +61,26 @@ def main(sim_dir, input_type, n_files_processed):
 
                 vert_id = vert['vertexID'][v_i]
 
-                nu_mu_bar = auxiliary.signal_nu_pdg(ghdr, vert_id)
-                nu_mu = auxiliary.wrong_sign_nu_pdg(ghdr, vert_id)
+                nu_mu = auxiliary.signal_nu_pdg(ghdr, vert_id) # nu_mu OR nu_mu_bar
                 is_cc = auxiliary.signal_cc(ghdr, vert_id)
                 mesonless = auxiliary.signal_meson_status(gstack, vert_id)
                 fv_particle_origin=twoBytwo_defs.fiducialized_particle_origin(traj, vert_id)
 
-                ### REQUIRE: (A) nu_mu_bar, (B) CC interaction, (C) NO final state mesons, (D) final state particle start point in FV
-                if nu_mu_bar==True and is_cc==True and mesonless==True and fv_particle_origin==True:
-                    sig_char.muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, muon_dict, wrong_sign=False)
-                    sig_char.hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, hadron_dict, wrong_sign=False)
+                ### REQUIRE: (A) nu_mu(_bar), (B) CC interaction, (C) NO final state mesons, (D) final state particle start point in FV
+                if nu_mu==True and is_cc==True and mesonless==True and fv_particle_origin==True:
+                    sig_char.muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, muon_dict)
+                    sig_char.hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, hadron_dict)
                     sig_char.get_truth_dict(spill_id, vert_id, ghdr, gstack, traj, vert, seg, signal_dict)
-                ### REQUIRE: (A) nu_mu, (B) CC interaction, (C) NO final state mesons, (D) final state particle start point in FV
-                elif nu_mu==True and is_cc==True and mesonless==True and fv_particle_origin==True:
-                    sig_char.muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, ws_muon_dict, wrong_sign=True)
-                    sig_char.hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, ws_hadron_dict, wrong_sign=True)
-                    sig_char.get_truth_dict(spill_id, vert_id, ghdr, gstack, traj, vert, seg, wrong_sign_bkg_dict)
 
     # Save all Python dictionaries to JSON files
     auxiliary.save_dict_to_json(signal_dict, "signal_dict", True)
-    auxiliary.save_dict_to_json(wrong_sign_bkg_dict, "wrong_sign_bkg_dict", True)
     auxiliary.save_dict_to_json(muon_dict, "muon_dict", True)
     auxiliary.save_dict_to_json(hadron_dict, "hadron_dict", True)
-    auxiliary.save_dict_to_json(ws_muon_dict, "ws_muon_dict", True)
-    auxiliary.save_dict_to_json(ws_hadron_dict, "ws_hadron_dict", True) 
 
     # Save full signal and w.s. bkg counts to TXT file
     signal_count = len(signal_dict)*scale_factor
-    wrong_sign_bkg_count = len(wrong_sign_bkg_dict)*scale_factor
-    outfile = open('signal_wrong_sign_bkg_event_counts.txt', "w")
+    outfile = open('signal_event_counts.txt', "w")
     outfile.writelines(["Signal Events (scaled to 2.5e19 POT): "+str(signal_count)+"\n", \
-                        "Wrong Sign Background Events (scaled to 2.5e19 POT): "+str(wrong_sign_bkg_count)+"\n", \
                         "Number of files used to get count: "+str(n_files_processed)+"\n", \
                         "Scale factor:"+str(scale_factor)+"\n"])
     outfile.close()
@@ -103,10 +88,6 @@ def main(sim_dir, input_type, n_files_processed):
     # PLOT: Signal Event Info      
     plot_muons(muon_dict, scale_factor, sig_bkg = 0)
     plot_hadrons(hadron_dict, scale_factor, sig_bkg = 0)
-
-    # PLOT: Wrong Sign Background Event Info   
-    plot_muons(ws_muon_dict, scale_factor, sig_bkg = 3)
-    plot_hadrons(ws_hadron_dict, scale_factor, sig_bkg = 3)
 
 
 if __name__=='__main__':

--- a/signal_kinematics.py
+++ b/signal_kinematics.py
@@ -69,7 +69,7 @@ def main(sim_dir, input_type, n_files_processed):
                 ### REQUIRE: (A) nu_mu(_bar), (B) CC interaction, (C) NO final state mesons, (D) final state particle start point in FV
                 if nu_mu==True and is_cc==True and mesonless==True and fv_particle_origin==True:
                     sig_char.muon_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, muon_dict)
-                    sig_char.hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, hadron_dict)
+                    sig_char.hadron_characterization(spill_id, vert_id, ghdr, gstack, traj, vert, seg, auxiliary.threshold, hadron_dict)
                     sig_char.get_truth_dict(spill_id, vert_id, ghdr, gstack, traj, vert, seg, signal_dict)
 
     # Save all Python dictionaries to JSON files

--- a/signal_plots_from_json_dicts.py
+++ b/signal_plots_from_json_dicts.py
@@ -11,12 +11,7 @@ import signal_characterization as sig_char
 from plot_signal_muons import plot_muons
 from plot_signal_hadrons import plot_hadrons
 
-def main(scale_factor, muon_json_file, hadron_json_file, wrong_sign):
-
-    if wrong_sign == False:
-        sb = 0
-    if wrong_sign == True:
-        sb = 3
+def main(scale_factor, muon_json_file, hadron_json_file):
 
     muon_file = open(muon_json_file)
     muon_dict=json.load(muon_file)
@@ -24,8 +19,8 @@ def main(scale_factor, muon_json_file, hadron_json_file, wrong_sign):
     hadron_file = open(hadron_json_file)
     hadron_dict=json.load(hadron_file)
 
-    plot_muons(muon_dict, scale_factor, sig_bkg = sb)
-    plot_hadrons(hadron_dict, scale_factor, sig_bkg = sb)
+    plot_muons(muon_dict, scale_factor, sig_bkg = 0)
+    plot_hadrons(hadron_dict, scale_factor, sig_bkg = 0)
 
 
 if __name__=='__main__':
@@ -36,7 +31,5 @@ if __name__=='__main__':
                         help='''string corresponding to the path of the muon info JSON file''')
     parser.add_argument('-had', '--hadron_json_file', default=None, required=True, type=str, \
                         help='''string corresponding to the path of the hadron info JSON file''')
-    parser.add_argument('-ws', '--wrong_sign', default=False, required=True, type=bool, \
-                        help='''bool corresponding to true for wrong sign background and false for signal''')
     args = parser.parse_args()
     main(**vars(args))

--- a/twoBytwo_defs.py
+++ b/twoBytwo_defs.py
@@ -14,6 +14,7 @@ loc_dict={'o':'Outside Active Volume',
           '6':'TPC 6',
           '7':'TPC 7'}
 
+# NOTE: not all possibilities have been considered for bkg e.g. for backwards tracks
 particle_end_loc_dict = {'f':'Stops in LAr Fiducial Volume',
                          'd':r'Stops in MINER$\nu$A Downstream',
                          'b':r'Exits back of MINER$\nu$A Downstream',


### PR DESCRIPTION
Includes changes to redefine signal as including events from muon neutrinos in addition to muon antineutrinos. Also includes basic infrastructure to characterize proton kinematics in signal events and a bug fix in the auxiliary.same_pdg_connected_trajectories method. Resolving this bug involved deciding that trajectories with matching PDG IDs are only connected if the "parent" trajectory has only one "child." For instance, if a proton track child has a proton track parent, but that proton parent has other "children" in addition to its proton child, the proton parent and child are NOT counted as the same particle. If, however, a proton track child has a proton track parent AND the proton parent has no other children, the trajectories of the proton parent and child are connected.